### PR TITLE
Fix specs to allow access to globals.

### DIFF
--- a/Verif_test.v
+++ b/Verif_test.v
@@ -43,3 +43,45 @@ Proof.
   start_function.
   repeat forward.
 Qed.
+
+Require VST.floyd.Funspec_old_Notation.
+
+Module old_version.
+(* Using [Funspec_old_Notation] *)
+  Import VST.floyd.Funspec_old_Notation.
+
+  Definition get_counter_spec:=
+  DECLARE _get_counter
+    WITH gv: globals, c: Z
+    PRE []
+      PROP (Int.min_signed <= c /\ c + 1 <= Int.max_signed)
+      LOCAL (gvars gv)
+      SEP (data_at Ews tint (Vint (Int.repr c)) (gv _COUNTER))
+    POST [ tint ]
+      PROP ()
+      RETURN (Vint (Int.repr (c + 1)))
+      SEP (data_at Ews tint (Vint (Int.repr (c + 1))) (gv _COUNTER)).
+
+
+  Definition main_spec :=
+  DECLARE _main
+    WITH gv : globals
+    PRE [] main_pre prog tt gv
+    POST [ tint ]
+      PROP()
+      RETURN (Vint (Int.repr 0))
+      SEP(TT).
+  Definition Gprog := [get_counter_spec; main_spec].
+
+Lemma get_counter_proof: semax_body Vprog Gprog f_get_counter get_counter_spec.
+Proof.
+  start_function.
+  repeat forward.
+Qed.
+
+Lemma body_main: semax_body Vprog Gprog f_main main_spec.
+Proof.
+  start_function.
+  repeat forward.
+Qed.
+End old_version.

--- a/Verif_test.v
+++ b/Verif_test.v
@@ -85,33 +85,3 @@ Proof.
   repeat forward.
 Qed.
 End old_version.
-
-(* Experiments
-
-Lemma get_counter_proof: semax_body Vprog Gprog f_get_counter get_counter_spec.
-Proof.
-  (* start_function1.
-  start_function2. *)
-  start_function.
-  (* rewrite (_ : @nil localdef = [gvars gv]). admit. *)
-  repeat forward.
-  entailer.
-  all: fail.
-Admitted.
-
-
-Eval cbv in prog_vars prog.
-(* Locate "WITH". *)
-Locate "PRE".
-Locate "LOCAL".
-Locate "SEP".
-Locate "PROP".
-Locate "DECLARE".
-Locate "PARAMS".
-(* PROPx
-NDmk_funspec
-PARAMSx
-SEPx
-LOCALx *)
-
-*)

--- a/Verif_test.v
+++ b/Verif_test.v
@@ -20,10 +20,25 @@ DECLARE _get_counter
     RETURN (Vint (Int.repr (c + 1)))
     SEP (data_at Ews tint (Vint (Int.repr (c + 1))) (gv _COUNTER)).
 
+Definition main_spec :=
+ DECLARE _main
+  WITH gv : globals
+  PRE [] main_pre prog tt gv
+  POST [ tint ]
+     PROP()
+     RETURN (Vint (Int.repr 0))
+     SEP(TT).
 
-Definition Gprog := [get_counter_spec].
+
+Definition Gprog := [get_counter_spec; main_spec].
 
 Lemma get_counter_proof: semax_body Vprog Gprog f_get_counter get_counter_spec.
+Proof.
+  start_function.
+  repeat forward.
+Qed.
+
+Lemma body_main: semax_body Vprog Gprog f_main main_spec.
 Proof.
   start_function.
   repeat forward.

--- a/Verif_test.v
+++ b/Verif_test.v
@@ -1,8 +1,8 @@
 Require Import VST.floyd.proofauto.
+Require Import test.
 Open Scope Z.
 
-Require Import test.
-Instance CompSpecs : compspecs. make_compspecs prog. Defined.
+#[export] Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 
 Definition get_counter_spec: ident * funspec :=

--- a/Verif_test.v
+++ b/Verif_test.v
@@ -85,3 +85,33 @@ Proof.
   repeat forward.
 Qed.
 End old_version.
+
+(* Experiments
+
+Lemma get_counter_proof: semax_body Vprog Gprog f_get_counter get_counter_spec.
+Proof.
+  (* start_function1.
+  start_function2. *)
+  start_function.
+  (* rewrite (_ : @nil localdef = [gvars gv]). admit. *)
+  repeat forward.
+  entailer.
+  all: fail.
+Admitted.
+
+
+Eval cbv in prog_vars prog.
+(* Locate "WITH". *)
+Locate "PRE".
+Locate "LOCAL".
+Locate "SEP".
+Locate "PROP".
+Locate "DECLARE".
+Locate "PARAMS".
+(* PROPx
+NDmk_funspec
+PARAMSx
+SEPx
+LOCALx *)
+
+*)

--- a/Verif_test.v
+++ b/Verif_test.v
@@ -9,7 +9,9 @@ Definition get_counter_spec: ident * funspec :=
 DECLARE _get_counter
   WITH gv: globals, c: Z
   PRE []
-    PROP ()
+    PROP (Int.min_signed <= c /\ c + 1 <= Int.max_signed)
+    (* NOT enough: try it!
+    PROP (Int.min_signed <= c + 1 <= Int.max_signed) *)
     PARAMS ()
     GLOBALS (gv)
     SEP (data_at Ews tint (Vint (Int.repr c)) (gv _COUNTER))
@@ -24,9 +26,5 @@ Definition Gprog := [get_counter_spec].
 Lemma get_counter_proof: semax_body Vprog Gprog f_get_counter get_counter_spec.
 Proof.
   start_function.
-  forward.
-  forward.
-  entailer!. { admit. }
-  forward.
-  forward.
-Admitted.
+  repeat forward.
+Qed.

--- a/Verif_test.v
+++ b/Verif_test.v
@@ -11,6 +11,7 @@ DECLARE _get_counter
   PRE []
     PROP ()
     PARAMS ()
+    GLOBALS (gv)
     SEP (data_at Ews tint (Vint (Int.repr c)) (gv _COUNTER))
   POST [ tint ]
     PROP ()
@@ -22,5 +23,10 @@ Definition Gprog := [get_counter_spec].
 
 Lemma get_counter_proof: semax_body Vprog Gprog f_get_counter get_counter_spec.
 Proof.
-  start_function. Fail forward.
+  start_function.
+  forward.
+  forward.
+  entailer!. { admit. }
+  forward.
+  forward.
 Admitted.

--- a/test.c
+++ b/test.c
@@ -9,5 +9,6 @@ int get_counter(void) {
 }
 
 int main(void) {
+    COUNTER = 1;
     return 0;
 }

--- a/test.c
+++ b/test.c
@@ -9,5 +9,5 @@ int get_counter(void) {
 }
 
 int main(void) {
-	return 0;
+    return 0;
 }

--- a/test.v
+++ b/test.v
@@ -112,7 +112,9 @@ Definition f_main := {|
   fn_temps := nil;
   fn_body :=
 (Ssequence
-  (Sreturn (Some (Econst_int (Int.repr 0) tint)))
+  (Ssequence
+    (Sassign (Evar _COUNTER tint) (Econst_int (Int.repr 1) tint))
+    (Sreturn (Some (Econst_int (Int.repr 0) tint))))
   (Sreturn (Some (Econst_int (Int.repr 0) tint))))
 |}.
 


### PR DESCRIPTION
Only tested on Apple Silicon's VST version — so you should probably regenerate the ASTs.

Reviewable by commit — I tested each commit compiles. (Details below).

---

Testing needed some build infrastructure, I approximated that with the following `_CoqProject` (the first line deals with a weird installation in the Coq platform I had).

```
-Q /Users/pgiarrusso1/.opam/__coq-platform.2022.09.0~8.16.0~2022.09~beta1/lib/coq-variant/VST_aarch64_64/VST VST
-Q . ""
```
and running:
```
coq_makefile -o Makefile *.v -f _CoqProject
git rebase main -x 'clightgen -normalize test.c; make Verif_test.vo -j; git restore test.v'
```